### PR TITLE
Quick-recording action (F#)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Here are all the actions that can be triggered from the MIDI keyboard:
 
 #### F# ⏐ *Quick-recording actions*
 
-* Press and release the key to start recording on the next free scene of all armed tracks.
+* Press and release the key to start a quick clip recording. This starts recording on the next free scene of all armed tracks, creating a new scene if necessary. If no track is armed the current track will be armed automatically if possible.
 
 #### G ⏐ *Clip actions*
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ RefaceCPLiveControl is an Ableton Live Control Surface script for the Yamaha Ref
 		3. [D  (*Play actions*)](#d--play-actions)
 		4. [E  (*Tempo actions*)](#e--tempo-actions)
 		5. [F  (*Track actions*)](#f--track-actions)
-		6. [G  (*Clip actions*)](#g--clip-actions)
-		7. [A  (*Device actions*)](#a--device-actions)
-		8. [A# (*Edit actions*)](#a--edit-actions)
-		9. [B  (*Loop actions*)](#b--loop-actions)
+		6. [F# (*Quick-recording actions*)](#f--quick-recording-actions)
+		7. [G  (*Clip actions*)](#g--clip-actions)
+		8. [A  (*Device actions*)](#a--device-actions)
+		9. [A# (*Edit actions*)](#a--edit-actions)
+		10. [B  (*Loop actions*)](#b--loop-actions)
 4. [Tips & Tricks](#tips--tricks)
 5. [Constraints](#constraints)
 6. [Troubleshooting](#troubleshooting)
@@ -209,6 +210,10 @@ Here are all the actions that can be triggered from the MIDI keyboard:
 * Press and hold + E to select to the previous track.
 * Press and hold + G to select to the next track.
 * Press and hold + A to select the current track's instrument.
+
+#### F# ⏐ *Quick-recording actions*
+
+* Press and release the key to start recording on the next free scene of all armed tracks.
 
 #### G ⏐ *Clip actions*
 

--- a/Reface_CP/SongUtil.py
+++ b/Reface_CP/SongUtil.py
@@ -9,6 +9,7 @@
 #
 # Distributed under the MIT License, see LICENSE
 
+import Live
 from Live.Device import Device
 from Live.Track import Track
 from Live.Song import Song, Quantization
@@ -75,6 +76,33 @@ class SongUtil:
             if next_clip_slot.has_clip:
                 song.view.highlighted_clip_slot = next_clip_slot
                 return
+            
+    @staticmethod
+    def find_first_free_scene_index(tracks):
+        """
+        Find the first free scene index in Ableton Live where all given tracks
+        have empty clip slots, starting from the last scene.
+        
+        Args:
+            tracks: The list of tracks.
+        
+        Returns:
+            int: The index of the first free scene, or -1 if none found.
+        """
+        song = Live.Application.get_application().get_document()
+        scenes = song.scenes
+        free_scene_index = -1
+        for scene_index in reversed(range(len(scenes))):
+            all_slots_empty = all(
+                track.clip_slots[scene_index].has_clip == False and track.clip_slots[scene_index].has_stop_button == True
+                for track in tracks
+            )
+            if all_slots_empty:
+                free_scene_index = scene_index
+            else:
+                return free_scene_index
+
+        return free_scene_index
 
 
     # - Device helpers

--- a/Reface_CP/SongUtil.py
+++ b/Reface_CP/SongUtil.py
@@ -104,6 +104,30 @@ class SongUtil:
 
         return free_scene_index
 
+    @staticmethod
+    def start_quick_recording():
+        """
+        Starts recording clips on the next free scene of all armed tracks, creating a new scene if necessary. 
+        If no track is armed the current track will be armed automatically if possible.
+        """
+        song = Live.Application.get_application().get_document()
+        armed_tracks = [track for track in song.tracks if track.can_be_armed and track.arm]
+        if not armed_tracks:
+            # Try auto-arm selected track
+            track = song.view.selected_track
+            if track.can_be_armed:
+                track.arm = True
+                if track.arm:
+                    armed_tracks = [track]
+            else:
+                return
+        scene_index = SongUtil.find_first_free_scene_index(armed_tracks)
+        if scene_index < 0:
+            song.create_scene(-1)
+            scene_index = len(song.scenes) - 1
+        for track in armed_tracks:
+            clip_slot = track.clip_slots[scene_index]
+            clip_slot.fire()
 
     # - Device helpers
 

--- a/Reface_CP/TransportController.py
+++ b/Reface_CP/TransportController.py
@@ -121,6 +121,8 @@ class TransportController:
                 self._logger.show_message("⚙︎ Release to toggle device/clip view. [M] Hold+C: Mute. [●] Hold+C#: Arm. [S] Hold+D: Solo. |←|→| Hold+E/G: Prev/Next track. 🎹 Hold+A: Select instrument.")
             else:
                 self._logger.show_message("⚙︎ Release to toggle device/clip view. [M] Hold+C: Mute. [●] Hold+C#: Arm. [S] Hold+D: Solo. |←|→| Hold+E/G: Prev/Next track.")
+        elif action == Note.f_sharp:
+            self._logger.show_message("● Release to start quick-recording.")
         elif action == Note.g:
             self._logger.show_message("[◼︎] Hold+C: Stop clip. [x] Hold+C#: Delete clip. [▶] Hold+D: Fire clip. [▶..] Hold+E: Fire scene. [←|→] Hold+F/A: Prev/Next clip slot.")
         elif action == Note.a:
@@ -158,6 +160,20 @@ class TransportController:
             else:
                 view.show_view("Detail/Clip")
                 self._logger.show_message("Toggle Clip View")
+
+        elif action == Note.f_sharp:
+            armed_tracks = [track for track in self._song.tracks if track.can_be_armed and track.arm]
+            if not armed_tracks:
+                # TODO: Auto-arm selected track option?
+                self._logger.show_message("No tracks armed for quick recording.")
+                return
+            scene_index = SongUtil.find_first_free_scene_index(armed_tracks)
+            if scene_index < 0:
+                self._song.create_scene(-1)
+                scene_index = len(self._song.scenes) - 1
+            for track in armed_tracks:
+                clip_slot = track.clip_slots[scene_index]
+                clip_slot.fire()
 
         elif action == Note.g:
             Live.Application.get_application().view.show_view("Detail/Clip")

--- a/Reface_CP/TransportController.py
+++ b/Reface_CP/TransportController.py
@@ -162,18 +162,7 @@ class TransportController:
                 self._logger.show_message("Toggle Clip View")
 
         elif action == Note.f_sharp:
-            armed_tracks = [track for track in self._song.tracks if track.can_be_armed and track.arm]
-            if not armed_tracks:
-                # TODO: Auto-arm selected track option?
-                self._logger.show_message("No tracks armed for quick recording.")
-                return
-            scene_index = SongUtil.find_first_free_scene_index(armed_tracks)
-            if scene_index < 0:
-                self._song.create_scene(-1)
-                scene_index = len(self._song.scenes) - 1
-            for track in armed_tracks:
-                clip_slot = track.clip_slots[scene_index]
-                clip_slot.fire()
+            SongUtil.start_quick_recording()
 
         elif action == Note.g:
             Live.Application.get_application().view.show_view("Detail/Clip")


### PR DESCRIPTION
Press and release the F# key to start a quick clip recording. 
This starts recording on the next free scene of all armed tracks, creating a new scene if necessary. 
If no track is armed the current track will be armed automatically if possible.