### PR TITLE
Quick recording selected/armed tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ Here are all the actions that can be triggered from the MIDI keyboard:
 
 #### F# ⏐ *Quick-recording actions*
 
-* Press and release the key to start a quick clip recording. This starts recording on the next free scene of all armed tracks, creating a new scene if necessary. If no track is armed the current track will be armed automatically if possible.
+* Press and release the key to start a quick clip recording on all selected tracks. This starts recording on the next free scene of all selected tracks, creating a new scene if necessary. If a track is not armed it will be armed automatically if possible.
+* Press and hold + C# to start a quick recording on all armed tracks. This starts recording clips on the next free scene of all armed tracks, creating a new scene if necessary.
 * Press and hold + G# to start a quick resampling. This starts recording a new clip in the next free scene of a track with a resampling input. If no resampling track is found a new one is created.
 
 #### G ⏐ *Clip actions*

--- a/Reface_CP/TransportController.py
+++ b/Reface_CP/TransportController.py
@@ -162,7 +162,8 @@ class TransportController:
                 self._logger.show_message("Toggle Clip View")
 
         elif action == Note.f_sharp:
-            SongUtil.start_quick_recording()
+            selected_tracks = SongUtil.find_selected_tracks()
+            SongUtil.start_quick_recording(tracks=selected_tracks, autoarm=True)
 
         elif action == Note.g:
             Live.Application.get_application().view.show_view("Detail/Clip")
@@ -292,7 +293,10 @@ class TransportController:
 
         # Quick-recording actions
         elif action == Note.f_sharp:
-            if subaction == Note.g_sharp and is_same_octave:
+            if subaction == Note.c_sharp and is_same_octave:
+                armed_tracks = SongUtil.find_armed_tracks()
+                SongUtil.start_quick_recording(tracks=armed_tracks)
+            elif subaction == Note.g_sharp and is_same_octave:
                 SongUtil.start_quick_resampling(select_first=True)
                 self._logger.show_message("Quick-resampling.")
 


### PR DESCRIPTION
Updated quick-recording actions:
* F# to start a quick recording on all selected tracks.
* F# + C# to start a quick recording on all armed tracks.