### PR TITLE
Midi track resampling action

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ Here are all the actions that can be triggered from the MIDI keyboard:
 
 * Press and release the key to start a quick clip recording on all selected tracks. This starts recording on the next free scene of all selected tracks, creating a new scene if necessary. If a track is not armed it will be armed automatically if possible.
 * Press and hold + C# to start a quick recording on all armed tracks. This starts recording clips on the next free scene of all armed tracks, creating a new scene if necessary.
-* Press and hold + F to start an audio track resampling. This starts recording a new clip into a track that takes audio from the selected track's output, creating a new track if none is found.
+* Press and hold + F to start an Audio track resampling. This starts recording a new Audio clip into a track that takes the audio signal from the selected track's output, creating a new track if none is found.
+* Press and hold + G to start a MIDI track resampling. This starts recording a new MIDI clip into a track that takes the MIDI signal from the selected track's output, creating a new track if none is found.
 * Press and hold + G# to start a quick resampling. This starts recording a new clip in the next free scene of a track with a resampling input. If no resampling track is found a new one is created.
 
 #### G ⏐ *Clip actions*

--- a/Reface_CP/SongUtil.py
+++ b/Reface_CP/SongUtil.py
@@ -254,6 +254,43 @@ class SongUtil:
         clip_slot = target_track.clip_slots[scene_index]
         clip_slot.fire()
 
+    @staticmethod
+    def start_track_midi_resampling(source_track: Track):
+        """
+        Start recording a new MIDI clip into a track that takes the MIDI signal from the given track's output, creating a new track if none is found.
+        """
+        if not source_track.has_midi_input: 
+            return
+        
+        song = Live.Application.get_application().get_document()
+        target_track = next((t for t in song.tracks if t.has_midi_input and t.input_routing_type.attached_object == source_track), None)
+        if target_track is None:
+            # Create track for resampling 
+            target_track_index = SongUtil.find_track_index(source_track)
+            if target_track_index < 0:
+                return
+            else:
+                target_track_index = target_track_index + 1
+            target_track = song.create_midi_track(target_track_index)
+            source_routing = next((routing for routing in target_track.available_input_routing_types if routing.attached_object == source_track), None)
+            if source_routing is None:
+                return
+            target_track.input_routing_type = source_routing
+        else:
+            song.view.selected_track = target_track
+
+        if target_track.can_be_armed and not target_track.arm:
+            target_track.arm = True
+        
+        target_track.current_monitoring_state = Track.monitoring_states.OFF
+
+        scene_index = SongUtil.find_first_free_scene_index([target_track])
+        if scene_index < 0:
+            song.create_scene(-1)
+            scene_index = len(song.scenes) - 1
+        clip_slot = target_track.clip_slots[scene_index]
+        clip_slot.fire()
+
     # - Device helpers
 
     @staticmethod

--- a/Reface_CP/TransportController.py
+++ b/Reface_CP/TransportController.py
@@ -122,7 +122,7 @@ class TransportController:
             else:
                 self._logger.show_message("⚙︎ Release to toggle device/clip view. [M] Hold+C: Mute. [●] Hold+C#: Arm. [S] Hold+D: Solo. |←|→| Hold+E/G: Prev/Next track.")
         elif action == Note.f_sharp:
-            self._logger.show_message("[●] Release to start quick-recording. [●|←] Hold+F: Audio track resample. │●…←│ Hold+G#: Quick-resampling.")
+            self._logger.show_message("[●] Release to start quick-recording. [●|←] Hold+F: Audio track resample. [●|←♪] Hold+G: MIDI track resample. │●…←│ Hold+G#: Quick-resampling.")
         elif action == Note.g:
             self._logger.show_message("[◼︎] Hold+C: Stop clip. [x] Hold+C#: Delete clip. [▶] Hold+D: Fire clip. [▶..] Hold+E: Fire scene. [←|→] Hold+F/A: Prev/Next clip slot.")
         elif action == Note.a:
@@ -299,6 +299,9 @@ class TransportController:
 
             elif subaction == Note.f and is_same_octave:
                 SongUtil.start_track_audio_resampling(self._song.view.selected_track)                
+
+            elif subaction == Note.g and is_same_octave:
+                SongUtil.start_track_midi_resampling(self._song.view.selected_track)  
 
             elif subaction == Note.g_sharp and is_same_octave:
                 SongUtil.start_quick_resampling(select_first=True)


### PR DESCRIPTION
Press F# + G to start a MIDI track resampling. This starts recording a new MIDI clip into a track that takes the MIDI signal from the selected track's output, creating a new track if none is found.